### PR TITLE
Automate Deploy Hyper Source from Network Drive

### DIFF
--- a/DeployfromNetwork
+++ b/DeployfromNetwork
@@ -1,0 +1,51 @@
+#
+#  Load DS from network drive and publish it
+from pathlib import Path
+import tableauserverclient as TSC
+
+hyper_name = 'C:xxx/My Tableau Repository/My Tableau Repository/Datasources/Test.hyper'
+server_address = 'https://tableaudvi.sddev.test.com'
+site_name = 'BIDData'
+project_name = 'Default'
+token_name = 'devtest'
+token_value = 'cxvvsggggssds...'
+
+# For more on tokens, head here:
+# https://help.tableau.com/current/server/en-us/security_personal_access_tokens.htm
+
+path_to_database = Path(hyper_name)
+
+# publish data source to Tableau server
+def publish_hyper():
+    """
+    Shows how to leverage the Tableau Server Client (TSC) to sign in and publish an extract directly to Tableau Online/Server
+    """
+
+    # Sign in to server
+    tableau_auth = TSC.PersonalAccessTokenAuth(token_name="devtest", personal_access_token="cxvvsggggssds...", site_id="BIData")
+    server = TSC.Server("https://tableaudvi.sddev.test.com", use_server_version=False)
+    server.add_http_options({'verify': False})
+        
+    print(f"Signing into {site_name} at {server_address}")
+    with server.auth.sign_in(tableau_auth):
+        # Define publish mode - Overwrite, Append, or CreateNew
+        publish_mode = TSC.Server.PublishMode.Overwrite
+        
+        # Get project_id from project_name
+        all_projects, pagination_item = server.projects.get()
+        for project in TSC.Pager(server.projects):
+            if project.name == project_name:
+                project_id = project.id
+    
+        # Create the datasource object with the project_id
+        datasource = TSC.DatasourceItem(project_id)
+        
+        print(f"Publishing {hyper_name} to {project_name}...")
+        # Publish datasource
+        datasource = server.datasources.publish(datasource, path_to_database, publish_mode)
+        print("Datasource published. Datasource ID: {0}".format(datasource.id))
+
+
+if __name__ == '__main__':
+    #insert_data()
+    publish_hyper()


### PR DESCRIPTION
This code utilizes Tableau server client API to do a simple hyper data source deploy to Tableau Dev server, as part of CI/CD pipeline process.   